### PR TITLE
Encoder limits as configurable parameters

### DIFF
--- a/ewellix_driver/include/ewellix_driver/ewellix_driver_plugin/hardware_interface.hpp
+++ b/ewellix_driver/include/ewellix_driver/ewellix_driver_plugin/hardware_interface.hpp
@@ -128,6 +128,7 @@ class EwellixHardwareInterface
   float conversion_;
   float rated_effort_;
   float tolerance_;
+  EwellixSerial::EncoderLimit encoder_limits_;
   std::vector<int>encoder_positions_, encoder_commands_;
   std::vector<uint16_t>speed_, speed_commands_;
   std::vector<double>positions_, position_commands_, old_positions_;

--- a/ewellix_driver/include/ewellix_driver/ewellix_node/ewellix_node.hpp
+++ b/ewellix_driver/include/ewellix_driver/ewellix_node/ewellix_node.hpp
@@ -90,8 +90,7 @@ private:
   float rated_effort_;
   float tolerance_;
   float frequency_;
-  int encoder_upper_limit_;
-  int encoder_lower_limit_;
+  EwellixSerial::EncoderLimit encoder_limits_;
   rclcpp::TimerBase::SharedPtr run_timer_;
 
   std::vector<int>encoder_positions_, encoder_commands_;

--- a/ewellix_driver/include/ewellix_driver/ewellix_node/ewellix_node.hpp
+++ b/ewellix_driver/include/ewellix_driver/ewellix_node/ewellix_node.hpp
@@ -90,6 +90,8 @@ private:
   float rated_effort_;
   float tolerance_;
   float frequency_;
+  int encoder_upper_limit_;
+  int encoder_lower_limit_;
   rclcpp::TimerBase::SharedPtr run_timer_;
 
   std::vector<int>encoder_positions_, encoder_commands_;

--- a/ewellix_driver/include/ewellix_driver/ewellix_serial/ewellix_serial.hpp
+++ b/ewellix_driver/include/ewellix_driver/ewellix_serial/ewellix_serial.hpp
@@ -180,10 +180,10 @@ class EwellixSerial
       BYTE = 0xFF
     };
 
-    enum EncoderLimit
+    struct EncoderLimit
     {
-      LOWER = 0,
-      UPPER = 865
+      int LOWER = 0;
+      int UPPER = 865;
     };
 
     class Status1

--- a/ewellix_driver/src/ewellix_driver_plugin/hardware_interface.cpp
+++ b/ewellix_driver/src/ewellix_driver_plugin/hardware_interface.cpp
@@ -497,13 +497,13 @@ EwellixHardwareInterface::convertCommands()
   for(int i = 0; i < joint_count_; i += 2)
   {
     encoder_commands_[i] = position_commands_[i] * conversion_;
-    if (encoder_commands_[i] < EwellixSerial::EncoderLimit::LOWER)
+    if (encoder_commands_[i] < encoder_limits_.LOWER)
     {
-      encoder_commands_[i] = EwellixSerial::EncoderLimit::LOWER;
+      encoder_commands_[i] = encoder_limits_.LOWER;
     }
-    if (encoder_commands_[i] > EwellixSerial::EncoderLimit::UPPER)
+    if (encoder_commands_[i] > encoder_limits_.UPPER)
     {
-      encoder_commands_[i] = EwellixSerial::EncoderLimit::UPPER;
+      encoder_commands_[i] = encoder_limits_.UPPER;
     }
     encoder_commands_[i + 1] = encoder_commands_[i];
   }

--- a/ewellix_driver/src/ewellix_node/ewellix_node.cpp
+++ b/ewellix_driver/src/ewellix_node/ewellix_node.cpp
@@ -45,8 +45,8 @@ EwellixNode::EwellixNode(const std::string node_name)
   this->declare_parameter("rated_effort", 2000.0);
   this->declare_parameter("tolerance", 0.005);
   this->declare_parameter("frequency", 10.0);
-  this->declare_parameter("encoder_upper_limit", EwellixSerial::EncoderLimit::UPPER);
-  this->declare_parameter("encoder_lower_limit", EwellixSerial::EncoderLimit::LOWER);
+  this->declare_parameter("encoder_upper_limit", encoder_limits_.UPPER);
+  this->declare_parameter("encoder_lower_limit", encoder_limits_.LOWER);
 
   // Get Parameters
   this->get_parameter("joint_count", joint_count_);
@@ -57,8 +57,8 @@ EwellixNode::EwellixNode(const std::string node_name)
   this->get_parameter("rated_effort", rated_effort_);
   this->get_parameter("tolerance", tolerance_);
   this->get_parameter("frequency", frequency_);
-  this->get_parameter("encoder_upper_limit", encoder_upper_limit_);
-  this->get_parameter("encoder_lower_limit", encoder_lower_limit_);
+  this->get_parameter("encoder_upper_limit", encoder_limits_.UPPER);
+  this->get_parameter("encoder_lower_limit", encoder_limits_.LOWER);
 
 
   RCLCPP_INFO(this->get_logger(),
@@ -306,13 +306,13 @@ EwellixNode::convertCommands()
   for(int i = 0; i < joint_count_; i++)
   {
     encoder_commands_[i] = position_commands_[i] * conversion_;
-    if (encoder_commands_[i] < encoder_lower_limit_)
+    if (encoder_commands_[i] < encoder_limits_.LOWER)
     {
-      encoder_commands_[i] = encoder_lower_limit_;
+      encoder_commands_[i] = encoder_limits_.LOWER;
     }
-    if (encoder_commands_[i] > encoder_upper_limit_)
+    if (encoder_commands_[i] > encoder_limits_.UPPER)
     {
-      encoder_commands_[i] = encoder_upper_limit_;
+      encoder_commands_[i] = encoder_limits_.UPPER;
     }
   }
 }

--- a/ewellix_driver/src/ewellix_node/ewellix_node.cpp
+++ b/ewellix_driver/src/ewellix_node/ewellix_node.cpp
@@ -45,6 +45,8 @@ EwellixNode::EwellixNode(const std::string node_name)
   this->declare_parameter("rated_effort", 2000.0);
   this->declare_parameter("tolerance", 0.005);
   this->declare_parameter("frequency", 10.0);
+  this->declare_parameter("encoder_upper_limit", EwellixSerial::EncoderLimit::UPPER);
+  this->declare_parameter("encoder_lower_limit", EwellixSerial::EncoderLimit::LOWER);
 
   // Get Parameters
   this->get_parameter("joint_count", joint_count_);
@@ -55,6 +57,9 @@ EwellixNode::EwellixNode(const std::string node_name)
   this->get_parameter("rated_effort", rated_effort_);
   this->get_parameter("tolerance", tolerance_);
   this->get_parameter("frequency", frequency_);
+  this->get_parameter("encoder_upper_limit", encoder_upper_limit_);
+  this->get_parameter("encoder_lower_limit", encoder_lower_limit_);
+
 
   RCLCPP_INFO(this->get_logger(),
   "\nParameters:\n  joint_count: %d\n  port: %s\n  baud: %d\n  timeout: %d\n  conversion: %f\n  rated_effort: %f\n  tolerance: %f\n  frequency: %f", joint_count_, port_.c_str(), baud_, timeout_, conversion_, rated_effort_, tolerance_, frequency_
@@ -301,13 +306,13 @@ EwellixNode::convertCommands()
   for(int i = 0; i < joint_count_; i++)
   {
     encoder_commands_[i] = position_commands_[i] * conversion_;
-    if (encoder_commands_[i] < EwellixSerial::EncoderLimit::LOWER)
+    if (encoder_commands_[i] < encoder_lower_limit_)
     {
-      encoder_commands_[i] = EwellixSerial::EncoderLimit::LOWER;
+      encoder_commands_[i] = encoder_lower_limit_;
     }
-    if (encoder_commands_[i] > EwellixSerial::EncoderLimit::UPPER)
+    if (encoder_commands_[i] > encoder_upper_limit_)
     {
-      encoder_commands_[i] = EwellixSerial::EncoderLimit::UPPER;
+      encoder_commands_[i] = encoder_upper_limit_;
     }
   }
 }


### PR DESCRIPTION
Added encoder limits as configurable parameters. The current driver has a hardcoded limit of 865, which is only suitable for a 500 mm stroke lift. For a 1400 mm stroke lift, it can go up to 2250. Issue #3 
Btw, thanks for this excellent work on the lift driver :)