### PR TITLE
fix: resolve compiler warnings in ewellix_driver

### DIFF
--- a/ewellix_driver/include/ewellix_driver/ewellix_driver_plugin/hardware_interface.hpp
+++ b/ewellix_driver/include/ewellix_driver/ewellix_driver_plugin/hardware_interface.hpp
@@ -124,7 +124,6 @@ class EwellixHardwareInterface
   protected:
   int joint_count_;
   bool activated_;
-  bool in_motion_;
   float conversion_;
   float rated_effort_;
   float tolerance_;

--- a/ewellix_driver/include/ewellix_driver/ewellix_node/ewellix_node.hpp
+++ b/ewellix_driver/include/ewellix_driver/ewellix_node/ewellix_node.hpp
@@ -88,7 +88,6 @@ private:
 
   int joint_count_;
   bool activated_;
-  bool in_motion_;
   float conversion_;
   float rated_effort_;
   float tolerance_;

--- a/ewellix_driver/src/ewellix_driver_plugin/hardware_interface.cpp
+++ b/ewellix_driver/src/ewellix_driver_plugin/hardware_interface.cpp
@@ -170,7 +170,7 @@ EwellixHardwareInterface::export_command_interfaces()
  * Parse the hardware parameters and attempt to open the given port.
  */
 hardware_interface::CallbackReturn
-EwellixHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous_state)
+EwellixHardwareInterface::on_configure(const rclcpp_lifecycle::State& /*previous_state*/)
 {
   RCLCPP_INFO(rclcpp::get_logger("EwellixHardwareInterface"), "Configuring...");
 
@@ -225,7 +225,7 @@ EwellixHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous_s
  * Send a stop command to clear all motion flags.
  */
 hardware_interface::CallbackReturn
-EwellixHardwareInterface::on_activate(const rclcpp_lifecycle::State& previous_state)
+EwellixHardwareInterface::on_activate(const rclcpp_lifecycle::State& /*previous_state*/)
 {
   RCLCPP_INFO(rclcpp::get_logger("EwellixHardwareInterface"), "Activating...");
 
@@ -294,7 +294,7 @@ EwellixHardwareInterface::on_activate(const rclcpp_lifecycle::State& previous_st
  * Send abort command to stop remote communication mode.
  */
 hardware_interface::CallbackReturn
-EwellixHardwareInterface::on_deactivate(const rclcpp_lifecycle::State& previous_state)
+EwellixHardwareInterface::on_deactivate(const rclcpp_lifecycle::State& /*previous_state*/)
 {
   RCLCPP_INFO(rclcpp::get_logger("EwellixHardwareInterface"), "Deactivating...");
 
@@ -314,7 +314,7 @@ EwellixHardwareInterface::on_deactivate(const rclcpp_lifecycle::State& previous_
  * Close the port.
  */
 hardware_interface::CallbackReturn
-EwellixHardwareInterface::on_cleanup(const rclcpp_lifecycle::State& previous_state)
+EwellixHardwareInterface::on_cleanup(const rclcpp_lifecycle::State& /*previous_state*/)
 {
   RCLCPP_INFO(rclcpp::get_logger("EwellixHardwareInterface"), "Cleanup...");
 
@@ -336,7 +336,7 @@ EwellixHardwareInterface::on_cleanup(const rclcpp_lifecycle::State& previous_sta
  * On Shutdown
  */
 hardware_interface::CallbackReturn
-EwellixHardwareInterface::on_shutdown(const rclcpp_lifecycle::State& previous_state)
+EwellixHardwareInterface::on_shutdown(const rclcpp_lifecycle::State& /*previous_state*/)
 {
   RCLCPP_INFO(rclcpp::get_logger("EwellixHardwareInterface"), "Shutdown...");
   return hardware_interface::CallbackReturn::SUCCESS;
@@ -346,7 +346,7 @@ EwellixHardwareInterface::on_shutdown(const rclcpp_lifecycle::State& previous_st
  * On Error
  */
 hardware_interface::CallbackReturn
-EwellixHardwareInterface::on_error(const rclcpp_lifecycle::State& previous_state)
+EwellixHardwareInterface::on_error(const rclcpp_lifecycle::State& /*previous_state*/)
 {
   RCLCPP_INFO(rclcpp::get_logger("EwellixHardwareInterface"), "Error!");
   return hardware_interface::CallbackReturn::SUCCESS;
@@ -360,7 +360,7 @@ EwellixHardwareInterface::on_error(const rclcpp_lifecycle::State& previous_state
  * Check if the lift is not at the commanded position and move.
  */
 hardware_interface::return_type
-EwellixHardwareInterface::read(const rclcpp::Time& time, const rclcpp::Duration& period)
+EwellixHardwareInterface::read(const rclcpp::Time& /*time*/, const rclcpp::Duration& period)
 {
   std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
   std::chrono::steady_clock::time_point end;
@@ -397,7 +397,7 @@ EwellixHardwareInterface::read(const rclcpp::Time& time, const rclcpp::Duration&
  * Write and read happens in read command.
  */
 hardware_interface::return_type
-EwellixHardwareInterface::write(const rclcpp::Time& time, const rclcpp::Duration& period)
+EwellixHardwareInterface::write(const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/)
 {
   return hardware_interface::return_type::OK;
 }

--- a/ewellix_driver/src/ewellix_serial/ewellix_serial.cpp
+++ b/ewellix_driver/src/ewellix_serial/ewellix_serial.cpp
@@ -89,7 +89,7 @@ EwellixSerial::open()
       serial_->open();
       return true;
     }
-    catch (serial::IOException e)
+    catch (const serial::IOException& e)
     {
       std::cout << __PRETTY_FUNCTION__ << ": IOException: " << e.what() << std::endl;
       return false;
@@ -489,7 +489,7 @@ EwellixSerial::send(const std::vector<uint8_t> message)
       serial_->write(message);
       serial_->flush();
     }
-    catch (serial::IOException e)
+    catch (const serial::IOException& e)
     {
       return false;
     }


### PR DESCRIPTION
## Summary

Fixes 10 compiler warnings that appear during builds of `ewellix_driver`, showing up as `2 packages had stderr output` in the colcon build summary.

**`-Wcatch-value` (2 instances)** — `ewellix_serial.cpp`:
- Change `catch (serial::IOException e)` → `catch (const serial::IOException& e)` to avoid slicing and unnecessary copy

**`-Wunused-parameter` (8 instances)** — `hardware_interface.cpp`:
- Comment out unused `previous_state` in `on_configure`, `on_activate`, `on_deactivate`, `on_cleanup`, `on_shutdown`, `on_error`
- Comment out unused `time` in `read` (`period` is used for velocity calculation)
- Comment out unused `time` and `period` in `write`

**`-Wunused-private-field` (1 instance)** — `ewellix_node.hpp` / `hardware_interface.hpp`:
- Remove unused `in_motion_` private field (never assigned or read in any source file)

## Test

Built cleanly with no warnings on arm64 (ROS 2 Humble).

🤖 Generated with [Claude Code](https://claude.com/claude-code)